### PR TITLE
Fix typo in Ohio county abbreviation mapping

### DIFF
--- a/routeGraphics.tcl
+++ b/routeGraphics.tcl
@@ -121,7 +121,7 @@ namespace eval routeGraphics {
 
     variable US_OH_county_abbr {
 	AUG AUGLAIZE
- 	BEL BELMONE
+ 	BEL BELMONT
 	COL COLUMBIANA
 	FAI FAIRFIELD
 	FUL FULTON


### PR DESCRIPTION
`BEL` stands for Belmont, not Belmone.